### PR TITLE
Fix code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/application.py
+++ b/application.py
@@ -157,8 +157,11 @@ def files():
 def view_file():
     filename = request.args.get('file')  # Paramètre `file` passé dans l'URL
     base_path = os.path.abspath('./files')  # Répertoire sécurisé
-    requested_path = os.path.abspath(os.path.join(base_path, filename))
+    requested_path = os.path.normpath(os.path.abspath(os.path.join(base_path, filename)))
 
+    # Vérifier que le chemin demandé est bien dans le répertoire sécurisé
+    if not requested_path.startswith(base_path):
+        abort(400, description="Invalid file path")
 
     try:
         with open(requested_path, 'r') as file:


### PR DESCRIPTION
Fixes [https://github.com/Sda223344/Formation-DSO/security/code-scanning/5](https://github.com/Sda223344/Formation-DSO/security/code-scanning/5)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder. This will prevent path traversal attacks by ensuring that the user cannot access files outside the intended directory.

We will modify the `view_file` function to include these checks and raise an exception if the path is not within the allowed directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
